### PR TITLE
use "-T linux" if $TERM is dumb or empty

### DIFF
--- a/script/functions.in
+++ b/script/functions.in
@@ -201,7 +201,11 @@ run_shutdown(){
 calc_columns
 
 # disable colors on broken terminals
-TERM_COLORS=$(tput colors 2>/dev/null)
+if [[ -z "$TERM" || "$TERM" = "dumb" ]]; then
+    TERM_COLORS=$(tput colors -T linux 2>/dev/null)
+else
+    TERM_COLORS=$(tput colors 2>/dev/null)
+fi
 if (( $? != 3 )); then
     case $TERM_COLORS in
         *[!0-9]*) USECOLOR="";;


### PR DESCRIPTION
Sorry for sending this one to a mirror but gitea registration is closed.

It's possible for `$TERM` to be `dumb` on bootup which causes `tput colors` to fail and thus the rest of the script. Workaround this by simply assuming $TERM can be linux if it is `dumb`.