### PR TITLE
binfmt.in: fix grep invocation

### DIFF
--- a/sv.d/binfmt.in
+++ b/sv.d/binfmt.in
@@ -10,7 +10,7 @@ mount_binfmt(){
     for path in /usr/lib/binfmt.d /etc/binfmt.d /run/binfmt.d; do
         [[ ! -d $path ]] && continue
         [[ -z "$(ls $path)" ]] && continue
-        grep "^:" $path/* | \
+        grep -h "^:" $path/* | \
             while read -r line; do
                 printf "%s" "$line" > /proc/sys/fs/binfmt_misc/register || return 1
             done


### PR DESCRIPTION
If any directory has more than one file, grep prefixes matching lines with
the filenames. -h suppresses that.

I reported that [here](https://forum.artixlinux.org/index.php/topic,1345.new.html#new).