### PR TITLE
udev.in: stop: only try to stop udevd when it's running

### DIFF
--- a/sv.d/udev.in
+++ b/sv.d/udev.in
@@ -5,19 +5,17 @@
 
 case "$1" in
     start)
-        # check if runit already runs udevd
-        if ! pgrep -f "runsv udevd" >/dev/null 2>&1; then
-            stat_busy "Starting udev daemon"
-            udevd --daemon || stat_die udev
-            # Note: This is only needed for initialization, udev will
-            #       be controlled by runit on stage 2.
-            add_daemon udev
-            stat_done udev
-        fi
+        stat_busy "Starting udev daemon"
+        udevd --daemon || stat_die udev
+        # Note: This is only needed for initialization, udev will
+        #       be controlled by runit on stage 2.
+        add_daemon udev
+        stat_done udev
         ;;
     stop)
         stat_busy "Stopping udev"
-        udevadm control --exit || stat_die udev
+        # check whether udevd might still be running.
+        ! pgrep -f "udevd" >/dev/null 2>&1 || udevadm control --exit || stat_die udev
         rm_daemon udev
         stat_done udev
         ;;


### PR DESCRIPTION
Since udevd is now started again in stage 2 and stopped by
runsvdir on shutdown, we only try to stop it with udevadm,
if there is an instance running.  This might be the case if
something went wrong and stage 2 couldn't start udevd for some
reason, so the instance from stage 1 wasn't terminated.

When starting udevd in stage 1, runsvdir isn't running yet, so
there is no need to check for already running instances.

---
Look [here](https://forum.artixlinux.org/index.php/topic,990.msg7466.html#msg7466) for background.